### PR TITLE
Ca injection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,10 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY . .
+COPY provisionners/ provisionners
+COPY controllers/ controllers
+COPY api/ api/
+COPY main.go main.go
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go


### PR DESCRIPTION
Fixed the CertShow() function that blocked user from using custom CA instead of the default IPA CA. 
Fixed an other issue were Certmanager was trying to read SHA Fingerprint, but CertShow would not output it due to missing "all" parameter 