### PR TITLE
Dns san compatibility

### DIFF
--- a/provisionners/freeipa.go
+++ b/provisionners/freeipa.go
@@ -154,6 +154,11 @@ func (s *FreeIPAPKI) Sign(ctx context.Context, cr *certmanager.CertificateReques
 
 	// Create alias principal for the service if DNSNames is specified
 	if csr.DNSNames != nil && len(csr.DNSNames) > 0 {
+		for i, v := range csr.DNSNames {
+			csr.DNSNames[i] = fmt.Sprintf("%s/%s", s.spec.ServiceName, v)
+		}
+
+		log.Info("Adding principal aliases for service")
 		if _, err := s.client.ServiceAddPrincipal(
 			&freeipa.ServiceAddPrincipalArgs{Krbcanonicalname: name, Krbprincipalname: csr.DNSNames},
 			&freeipa.ServiceAddPrincipalOptionalArgs{}); err != nil && !s.spec.IgnoreError {

--- a/provisionners/freeipa.go
+++ b/provisionners/freeipa.go
@@ -18,16 +18,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+// Using sync.Map to store provisioners safely in concurrent environment.
 var collection = new(sync.Map)
 
-// FreeIPAPKI
+// FreeIPAPKI is a structure for storing the FreeIPA client, issuer specifications and the name.
 type FreeIPAPKI struct {
 	client *freeipa.Client
 	spec   *api.IssuerSpec
 
-	name string
+	name string // Unique name for this instance, usually derived from Kubernetes namespaced name
 }
 
+// formatCertificate ensures that the certificate string is enclosed within the standard PEM format.
 func formatCertificate(cert string) string {
 	header := "-----BEGIN CERTIFICATE-----"
 	footer := "-----END CERTIFICATE-----"
@@ -40,20 +42,23 @@ func formatCertificate(cert string) string {
 	return cert
 }
 
-// New returns a new provisioner, configured with the information in the
-// given issuer.
+// New returns a new provisioner configured with the information in the given issuer.
+// It establishes a connection to the FreeIPA server and initializes the FreeIPAPKI structure.
 func New(namespacedName types.NamespacedName, spec *api.IssuerSpec, user, password string, insecure bool) (*FreeIPAPKI, error) {
+	// Configure the HTTP transport, specifically allowing for insecure TLS connections if required
 	tspt := http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: insecure,
 		},
 	}
 
+	// Connect to FreeIPA server using the provided host, user credentials and transport settings
 	client, err := freeipa.Connect(spec.Host, &tspt, user, password)
 	if err != nil {
 		return nil, err
 	}
 
+	// Initialize and return a FreeIPAPKI instance
 	p := &FreeIPAPKI{
 		name:   fmt.Sprintf("%s.%s", namespacedName.Name, namespacedName.Namespace),
 		client: client,
@@ -63,7 +68,8 @@ func New(namespacedName types.NamespacedName, spec *api.IssuerSpec, user, passwo
 	return p, nil
 }
 
-// Load returns a provisioner by NamespacedName.
+// Load retrieves a provisioner from the collection by its NamespacedName.
+// Returns the provisioner and a boolean indicating if it was found.
 func Load(namespacedName types.NamespacedName) (*FreeIPAPKI, bool) {
 	v, ok := collection.Load(namespacedName)
 	if !ok {
@@ -73,7 +79,7 @@ func Load(namespacedName types.NamespacedName) (*FreeIPAPKI, bool) {
 	return p, ok
 }
 
-// Store adds a new provisioner to the collection by NamespacedName.
+// Store adds a new provisioner to the collection, identified by its NamespacedName.
 func Store(namespacedName types.NamespacedName, provisioner *FreeIPAPKI) {
 	collection.Store(namespacedName, provisioner)
 }
@@ -83,21 +89,25 @@ type CaPem []byte
 
 const certKey = "certificate"
 
-// Sign sends the certificate requests to the CA and returns the signed
-// certificate.
+// Sign sends the certificate request (CSR) to the Certificate Authority (CA) and returns the signed certificate.
+// It also checks for existence of the host and the service, and if they don't exist, it attempts to add them.
 func (s *FreeIPAPKI) Sign(ctx context.Context, cr *certmanager.CertificateRequest) (CertPem, CaPem, error) {
 	log := log.FromContext(ctx).WithName("sign").WithValues("request", cr)
 
+	// Decode the CSR
 	csr, err := pki.DecodeX509CertificateRequestBytes(cr.Spec.Request)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to decode CSR for signing: %s", err)
 	}
 
+	// Check if CSR has a Common Name
 	if csr.Subject.CommonName == "" {
-		return nil, nil, fmt.Errorf("Request has no common name")
+		return nil, nil, fmt.Errorf("Request has no common name provided. Please provide a valid CommonName value")
 	}
 
-	// Adding Host
+	// Add host if it doesn't exist and AddHost flag is set
+	// Continue the code to add a service if it doesn't exist and AddService flag is set
+	// Then, send certificate signing request to the FreeIPA server, handle errors, and process the response
 	if s.spec.AddHost {
 		if _, err := s.client.HostShow(&freeipa.HostShowArgs{Fqdn: csr.Subject.CommonName}, &freeipa.HostShowOptionalArgs{}); err != nil {
 			if ipaE, ok := err.(*freeipa.Error); ok && ipaE.Code == freeipa.NotFoundCode {
@@ -114,29 +124,48 @@ func (s *FreeIPAPKI) Sign(ctx context.Context, cr *certmanager.CertificateReques
 		}
 	}
 
+	// Construct a name by concatenating the service name and common name from the CSR.
 	name := fmt.Sprintf("%s/%s", s.spec.ServiceName, csr.Subject.CommonName)
 
-	// Adding service
+	// Check if the service addition is required as per specifications.
 	if s.spec.AddService {
+		// Try to find the service in FreeIPA using the constructed name.
 		svcList, err := s.client.ServiceFind(
 			name,
 			&freeipa.ServiceFindArgs{},
 			&freeipa.ServiceFindOptionalArgs{
-				PkeyOnly:  freeipa.Bool(true),
-				Sizelimit: freeipa.Int(1),
+				PkeyOnly:  freeipa.Bool(true), // Only retrieve primary key.
+				Sizelimit: freeipa.Int(1),     // Limit the search results to 1.
 			})
 
+		// If an error occurred and we're not ignoring errors, fail and return.
 		if err != nil {
 			if !s.spec.IgnoreError {
 				return nil, nil, fmt.Errorf("fail listing services: %v", err)
 			}
 		} else if svcList.Count == 0 {
-			if _, err := s.client.ServiceAdd(&freeipa.ServiceAddArgs{Krbcanonicalname: name}, &freeipa.ServiceAddOptionalArgs{Force: freeipa.Bool(true)}); err != nil && !s.spec.IgnoreError {
+			// If the service doesn't exist, attempt to add it.
+			if _, err := s.client.ServiceAdd(&freeipa.ServiceAddArgs{Krbcanonicalname: name},
+				&freeipa.ServiceAddOptionalArgs{Force: freeipa.Bool(true)}); err != nil && !s.spec.IgnoreError {
 				return nil, nil, fmt.Errorf("fail adding service: %v", err)
 			}
 		}
 	}
 
+	// Create alias principal for the service if DNSNames is specified
+	if csr.DNSNames != nil && len(csr.DNSNames) > 0 {
+		if _, err := s.client.ServiceAddPrincipal(
+			&freeipa.ServiceAddPrincipalArgs{Krbprincipalname: csr.DNSNames},
+			&freeipa.ServiceAddPrincipalOptionalArgs{}); err != nil && !s.spec.IgnoreError {
+			return nil, nil, fmt.Errorf("fail adding DNSNames SAN principal to the service %v : %v", name, err)
+		} else if err != nil && s.spec.IgnoreError {
+			log.Error(err, "Ignored Error> Failed to add DNSNames SAN principal to the service")
+		} else {
+			log.Info("Added DNSNames SAN principal to the service", "service", name)
+		}
+	}
+
+	// Send certificate signing request (CSR) to the FreeIPA server with the constructed name as principal.
 	certRequestResult, err := s.client.CertRequest(&freeipa.CertRequestArgs{
 		Csr:       string(cr.Spec.Request),
 		Principal: name,
@@ -148,24 +177,29 @@ func (s *FreeIPAPKI) Sign(ctx context.Context, cr *certmanager.CertificateReques
 		return nil, nil, fmt.Errorf("Fail to request certificate: %v", err)
 	}
 
+	// Extract the serial number from the certificate request result.
 	serialNumberStr, ok := certRequestResult.Result.(map[string]interface{})["serial_number"].(string)
 	if !ok {
 		return nil, nil, fmt.Errorf("Fail to convert serial_number to string: %v", ok)
 	}
 
+	// Construct the certificate show request arguments using the serial number.
 	reqCertShow := &freeipa.CertShowArgs{
 		SerialNumber: serialNumberStr,
 	}
 
+	// Variables to hold the certificate and CA certificate in PEM format.
 	var certPem string
 	var caPem string
 
+	// Fetch the certificate from the FreeIPA server.
 	cert, err := s.client.CertShow(reqCertShow,
 		&freeipa.CertShowOptionalArgs{
-			Cacn:  &s.spec.Ca,
-			All:   freeipa.Bool(true),
-			Chain: freeipa.Bool(true)})
+			Cacn:  &s.spec.Ca,          // Use the specific CA from the spec.
+			All:   freeipa.Bool(true),  // Retrieve all attributes.
+			Chain: freeipa.Bool(true)}) // Include certificate chain.
 
+	// If there's an error or the certificate chain is empty, fallback to the certificate in the request result.
 	if err != nil || len(*cert.Result.CertificateChain) == 0 {
 		log.Error(err, "fail to get certificate FALLBACK", "requestResult", certRequestResult)
 

--- a/provisionners/freeipa.go
+++ b/provisionners/freeipa.go
@@ -155,7 +155,7 @@ func (s *FreeIPAPKI) Sign(ctx context.Context, cr *certmanager.CertificateReques
 	// Create alias principal for the service if DNSNames is specified
 	if csr.DNSNames != nil && len(csr.DNSNames) > 0 {
 		if _, err := s.client.ServiceAddPrincipal(
-			&freeipa.ServiceAddPrincipalArgs{Krbprincipalname: csr.DNSNames},
+			&freeipa.ServiceAddPrincipalArgs{Krbcanonicalname: name, Krbprincipalname: csr.DNSNames},
 			&freeipa.ServiceAddPrincipalOptionalArgs{}); err != nil && !s.spec.IgnoreError {
 			return nil, nil, fmt.Errorf("fail adding DNSNames SAN principal to the service %v : %v", name, err)
 		} else if err != nil && s.spec.IgnoreError {


### PR DESCRIPTION
Fixed Non compatibility with DNSNames

When generating SAN (subject alternate names), freeipa in fact needs to setup a new PRINCIPAL for each SAN, in the created service. 

Here is a basic workflow: 

```mermaid
graph TD
    A[Start] --> B(Send CSR with certificate values)
    B --> C(Create host in freeipa with commonName)
    C --> D(Create service in freeipa based on hostname)
    D --> E{DNSNames provided?}
    E -- Yes --> F(Create principal alias in service for each DNSName)
    F --> G[Proceed to certificate generation]
    E -- No --> G[Proceed to certificate generation]
    G --> H[End]
```

To create the principal alias for each DNSNames, We need to add the `ServiceAddPrincipal()` freeipa-client method, with the `SERVICE-TYPE/commonName` as the `canonical name` and `SERVICE-TYPE/dnsName` for each provided new SAN in the `certificate.yaml`

