### PR TITLE
Fix dns ignore error field

### DIFF
--- a/provisionners/freeipa.go
+++ b/provisionners/freeipa.go
@@ -163,8 +163,6 @@ func (s *FreeIPAPKI) Sign(ctx context.Context, cr *certmanager.CertificateReques
 			&freeipa.ServiceAddPrincipalArgs{Krbcanonicalname: name, Krbprincipalname: csr.DNSNames},
 			&freeipa.ServiceAddPrincipalOptionalArgs{}); err != nil && !s.spec.IgnoreError {
 			return nil, nil, fmt.Errorf("fail adding DNSNames SAN principal to the service %v : %v", name, err)
-		} else if err != nil && s.spec.IgnoreError {
-			log.Error(err, "Ignored Error> Failed to add DNSNames SAN principal to the service")
 		} else {
 			log.Info("Added DNSNames SAN principal to the service", "service", name)
 		}

--- a/provisionners/freeipa.go
+++ b/provisionners/freeipa.go
@@ -198,9 +198,8 @@ func (s *FreeIPAPKI) Sign(ctx context.Context, cr *certmanager.CertificateReques
 	// Fetch the certificate from the FreeIPA server.
 	cert, err := s.client.CertShow(reqCertShow,
 		&freeipa.CertShowOptionalArgs{
-			Cacn:  &s.spec.Ca,          // Use the specific CA from the spec.
-			All:   freeipa.Bool(true),  // Retrieve all attributes.
-			Chain: freeipa.Bool(true)}) // Include certificate chain.
+			Cacn: &s.spec.Ca,
+			All:  freeipa.Bool(true)})
 
 	// If there's an error or the certificate chain is empty, fallback to the certificate in the request result.
 	if err != nil || len(*cert.Result.CertificateChain) == 0 {
@@ -210,10 +209,12 @@ func (s *FreeIPAPKI) Sign(ctx context.Context, cr *certmanager.CertificateReques
 		if !ok || c == "" {
 			return nil, nil, fmt.Errorf("can't find certificate for: %s", certRequestResult.String())
 		}
-
 		certPem = formatCertificate(c)
 	} else {
 		for i, c := range *cert.Result.CertificateChain {
+			if len(strings.Replace(c, "\n", "", -1)) == 0 {
+				continue
+			}
 			c = formatCertificate(c)
 			if i == 0 {
 				certPem = c


### PR DESCRIPTION
Removed the condition where, if freeipa failed to add the DNSNames as principal aliases in the service, it would still proceed and try to create the certificate. This condition was useless and missleading, as freeeipa certificate generation will fail anyway, because the CSR contains the DNSNames, and freeipa wont find them as aliases in the service when creating the cert